### PR TITLE
Bug fix for newer Android versions

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,12 +3,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.tunes.viewer"
-      android:versionCode="17" android:versionName="1.3.0">
+      android:versionCode="18" android:versionName="1.3.1">
       <!-- Android tablet compatibility -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -19,7 +19,7 @@
         </service> -->
 
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
      * of the Gradle plugin for the buildscript.
      */
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
 
 
 
@@ -39,9 +39,9 @@ apply plugin: 'com.android.application'
  * following line includes all the JAR files in the libs directory.
  */
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "com.android.support:support-core-utils:26.1.0"
+    implementation 'androidx.legacy:legacy-support-core-utils:1.0.0'
     // Add other library dependencies here (see the next step)
 }
 
@@ -51,7 +51,7 @@ dependencies {
  */
 android {
     useLibrary  'org.apache.http.legacy'
-    compileSdkVersion 26
+    compileSdkVersion 29
     buildToolsVersion "28.0.3"
 
     /**
@@ -86,6 +86,6 @@ android {
     }
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 29
     }
 }

--- a/src/com/tunes/viewer/FileDownload/Notifier.java
+++ b/src/com/tunes/viewer/FileDownload/Notifier.java
@@ -90,7 +90,8 @@ public class Notifier {
 		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)
 		{
 			int importance = NotificationManager.IMPORTANCE_HIGH;
-			NotificationChannel notificationChannel = new NotificationChannel(NotificationChannel.DEFAULT_CHANNEL_ID, "NOTIFICATION_CHANNEL_NAME", importance);
+			String notificationChannelId = "tunesviewer_app_notifications";
+			NotificationChannel notificationChannel = new NotificationChannel(notificationChannelId, "NOTIFICATION_CHANNEL_NAME", importance);
 			notificationChannel.enableLights(false);
 			notificationChannel.enableVibration(false);
 			//mBuilder.setChannelId(NOTIFICATION_CHANNEL_ID);

--- a/src/com/tunes/viewer/WebView/JSInterface.java
+++ b/src/com/tunes/viewer/WebView/JSInterface.java
@@ -31,7 +31,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.text.ClipboardManager;
 import android.util.Log;
 import android.widget.TextView;


### PR DESCRIPTION
Resolves #1 .

**Bug description**

Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel. The `DownloadService` service class in the app attempts to create a notification channel with `NotificationChannel.DEFAULT_CHANNEL_ID` as channel ID. But since this channel ID is reserved by Android System, it throws a `RuntimeException`, thus resulting in app crash.

**Solution**

Replace `NotificationChannel.DEFAULT_CHANNEL_ID` with a custom channel ID string for the app's notification channel.

**Additional changes**

* Migrates the app to AndroidX. 
* Updates the app to target SDK version 29 (Android 10).